### PR TITLE
BUGFIX: prevent default event behavior

### DIFF
--- a/src/a2lix_sf_collection.js
+++ b/src/a2lix_sf_collection.js
@@ -112,11 +112,11 @@ a2lix_lib.sfCollection = (() => {
   }
 
   const triggerEntryAction = (evt, cfg) => {
-    evt.preventDefault()
-
     if (!evt.target.hasAttribute('data-entry-action')) {
       return
     }
+
+    evt.preventDefault()
 
     switch (evt.target.getAttribute('data-entry-action')) {
       case 'add':


### PR DESCRIPTION
Only prevent default event behavior if clicked element is an element of concern.

This PR fixes this issue: https://github.com/a2lix/symfony-collection/issues/19

The problem is that preventing default behavior of a click event on the whole collection item element breaks other custom functionality which is tied to that event.